### PR TITLE
Fix enum mismatch

### DIFF
--- a/uchess.h
+++ b/uchess.h
@@ -27,7 +27,7 @@ struct Position {
 	bitboard white, X, Y, Z;
 };
 
-enum Color { BLACK, WHITE };
+enum Color { WHITE, BLACK };
 
 struct State {
 	struct Position pos;


### PR DESCRIPTION
In `state.h`, `Color` is defined as
`enum Color { WHITE, BLACK };`,
but in `uchess.h`, it is defined as
`enum Color { BLACK, WHITE };`.
This patch fixes the discrepancy.